### PR TITLE
remove use of ShadowTree from AbstractTrees

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,4 +8,4 @@ AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 
 [compat]
 julia = "1.4"
-AbstractTrees = "0.3"
+AbstractTrees = "0.3, 0.4"

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -59,12 +59,12 @@ function toDotContent(tree, parent_id)
     out
 end
 
-function toStatusDotContent(tree, parent_id)
-    name = BehaviorTree.format(tree.tree.x)
+function toStatusDotContent(tree, results, parent_id)
+    name = BehaviorTree.format(tree)
     node_id = string(parent_id, replace(name, "!"=>""))
     if length(children(tree)) == 0
         shape = if startswith(name, "is") "ellipse" else "box" end
-        color = colors[tree.shadow.x]
+        color = colors[results]
         return string([
             """$node_id:n\n""",
             """$node_id [shape=$shape, label="$name", style=filled,color="$color"]\n""",
@@ -72,9 +72,9 @@ function toStatusDotContent(tree, parent_id)
         ]...)
     end
     shape = "box"
-    label = if(typeof(tree.tree.x) == Selector) "?" else "->" end
+    label = if(typeof(tree) == Selector) "?" else "->" end
     #TODO: more efficient implementation?
-    lastchild = tree.shadow.x
+    lastchild = results
     while length(children(lastchild)) > 0
         lastchild = last(children(lastchild))
     end
@@ -82,7 +82,7 @@ function toStatusDotContent(tree, parent_id)
     out = string(
         """$node_id:n\n""",
         """$node_id [shape=$shape, label="$label", style=filled, color="$color"]\n""",
-        ["""$(toStatusDotContent(c, node_id))\n""" for c in children(tree)]...)
+        ["""$(toStatusDotContent(a, b, node_id))\n""" for (a,b) in zip(children(tree), children(results))]...)
     if parent_id != ""
         out = string(
             out,
@@ -92,8 +92,7 @@ function toStatusDotContent(tree, parent_id)
     out
 end
 function toDot(tree::BT, results)
-    st = ShadowTree(tree, results)
-    content = toStatusDotContent(st, "")
+    content = toStatusDotContent(tree, results, "")
     return """digraph tree {
     $(content)
     }"""


### PR DESCRIPTION
Hello, I have been working on a major overhaul of [AbstractTrees.jl](https://github.com/JuliaCollections/AbstractTrees.jl) on which this package depends.  BehaviorTree.jl turns out to be unique in that it is the only registered package which uses the struct `ShadowTree`.  We are looking to deprecate this struct.  The intended use of the struct was mysterious to me.  I took the time to dig into BehaviorTree.jl a bit because I needed to understand what the implications of deprecating that struct would be.

Turns out this package wasn't really using the struct, or rather it was not using any features that are not trivially reproducible with other methods (in this case a call to `zip`).  I suspect when you wrote this code you found yourself in a familiar situation: you had in your mind some use for `ShadowTree` but it turned out not to be very useful after all.  I've been through something similar myself, even after a lot of work on AbstractTrees.jl, it was hard to see why `ShadowTree` would ever be very useful.

If you think what is done here does *NOT* provide the same functionality it did without `ShadowTree`, please open an issue in AbstractTrees.jl.